### PR TITLE
Fix for CUDAERROR in binning MP

### DIFF
--- a/labs/binning/rai_build.yml
+++ b/labs/binning/rai_build.yml
@@ -4,6 +4,10 @@ rai:
 resources:
   cpu:
     architecture: ppc64le
+  gpu:
+    count: 1
+  network: false
+  cache: false
 commands:
   build:
     - cp -r /src .


### PR DESCRIPTION
The issue was rai_build.yml file in latest update does not include GPU related functionalities enabled.. 

Critical:: ERROR[CUDA driver version is insufficient for CUDA runtime version] on /src/common/utils.hpp::340 In timer_entry:(cudaEventCreate(&start)) FAILED
binning: /src/common/utils.hpp:100: void detail::logger::critical(const string&): Assertion `0' failed.